### PR TITLE
Feature/updates: Add county level data

### DIFF
--- a/deploy.Rmd
+++ b/deploy.Rmd
@@ -30,7 +30,7 @@ rsconnect::setAccountInfo(
   secret="<SECRET>"
 )
 
-deployApp()
+deployApp(appFiles = "app.R")
 ```
  
  

--- a/deploy.Rmd
+++ b/deploy.Rmd
@@ -1,0 +1,36 @@
+---
+title: "Deploy"
+author: "Sean Kent"
+date: "3/23/2020"
+output: html_document
+---
+
+## Instructions
+
+'Knit' this file to reload the data from Corona Data Scraper and deploy the app.  Alternatively, one can run all chunks.
+
+### Step 1: Re-download county level data file
+
+```{r}
+# Re-download the file from Corona Data Scraper to prevent download on each Shiny session (time consuming)
+download.file("https://coronadatascraper.com/timeseries-tidy.csv",
+              destfile = "data/timeseries-tidy.csv")
+
+```
+
+### Step 2: Deploy the app
+
+```{r}
+library(rsconnect)
+
+# TODO: need to set this up manually.  Look under Tokens from the Profile section
+rsconnect::setAccountInfo(
+  name="<ACCOUNT>",
+  token="<TOKEN>",
+  secret="<SECRET>"
+)
+
+deployApp()
+```
+ 
+ 


### PR DESCRIPTION
Creating a pull request to add the county-level information from Corona Data Scraper (https://coronadatascraper.com/#home) to the pandemic app.   Some additional modifications to the app UI in the real cases tab are included.  

**Problem**: the county-level data is very large, and thus could not be downloaded from URL each time the app runs.  
**Solution**: Data is saved in the repository so it only needs to be read by the app each time, instead of being downloaded each time.  I wrote a deploy.Rmd which will update the data from Corona Data Scraper, save it in the correct place, and then re-deploy the app.  I am unable to test the deployment, and it still needs the correct account number and token, but with those changes, it should save time.  County-level data will only update when this script is re-run.   