### PR TITLE
fix state double counting

### DIFF
--- a/app.R
+++ b/app.R
@@ -64,6 +64,7 @@ real_cases_cds <- function() {
   }
   read.csv(dirpath) %>%
     filter(city == "") %>% # remove any city level data
+    filter(county != "") %>% # remove state/region aggregate counts
     filter(type %in% c("cases", "deaths", "recovered")) %>% # also have active, growthFactor for some
     select(type, county, state, country, date, value, population) %>% 
     mutate_at(vars(type, county, state, country), as.character) %>% 


### PR DESCRIPTION
- Remove the state level aggregates from the county data which were
causing state totals to be double what they should be